### PR TITLE
New method for SQRT

### DIFF
--- a/_math.scss
+++ b/_math.scss
@@ -242,13 +242,22 @@ $iter: 50;
   } 
 }
 
+@function root($number, $n) {
+  @return n-root($number, $n);
+}
+
 // Square Roots
 @function √($number) {
-  @return n-root($number, 2); 
+  @return sqrt($number); 
 }
 
 @function sqrt($number) {
-  @return n-root($number, 2); 
+  $guess: rand();
+  $root: $guess;
+  @for $i from 1 through $iter {
+    $root: $root - (pow($root, 2) - $number) / (2 * $root);
+  }
+  @return $root;
 }
 
 //////////////////////////////
@@ -265,4 +274,5 @@ $iter: 50;
   width: cos($pi / 2, 'rad'); 
   width: cos(10deg);
   width: ln(.1);
+  height: sqrt(25.4);
 }


### PR DESCRIPTION
Updated SQRT to use Newton's Method for calculating. Cannot be expanded to nth root (at least not yet), but will accurately calculate SQRT of any number greater than zero, including decimals.
