### PR TITLE
Correct semver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sassy-math",
-  "version": "1.5",
+  "version": "1.5.0",
   "main": "compass/stylesheets/_math.scss",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
The bower.json had a non-semver version number the first time around.
